### PR TITLE
Add artifacts to download the compiled resources on GitHub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,10 @@ jobs:
     - name: Build linux-i386
       run: |
         scripts/build-ubuntu-i386.sh
+    - uses: actions/upload-artifact@v2
+      with:
+        name: Source Engine - Linux 32-bit
+        path: build/*.zip
 
   build-linux-amd64:
     runs-on: ubuntu-18.04
@@ -26,6 +30,10 @@ jobs:
     - name: Build linux-amd64
       run: |
         scripts/build-ubuntu-amd64.sh
+    - uses: actions/upload-artifact@v2
+      with:
+        name: Source Engine - Linux 64-bit
+        path: build/*.zip
 
   build-android-armv7a:
     runs-on: ubuntu-18.04
@@ -35,6 +43,10 @@ jobs:
     - name: Build android-armv7a
       run: |
         scripts/build-android-armv7a.sh
+    - uses: actions/upload-artifact@v2
+      with:
+        name: Source Engine - Android armv7a
+        path: build/*.zip
 
   build-windows-i386:
     runs-on: windows-2019
@@ -46,6 +58,10 @@ jobs:
         git submodule init && git submodule update
         ./waf.bat configure -T debug
         ./waf.bat build
+    - uses: actions/upload-artifact@v2
+      with:
+        name: Source Engine - Windows 32-bit
+        path: build/*.zip
 
   build-dedicated-windows-i386:
     runs-on: windows-2019

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,11 @@ jobs:
     - name: Build linux-i386
       run: |
         scripts/build-ubuntu-i386.sh
+        zip -r build-linux-i386.zip build
     - uses: actions/upload-artifact@v2
       with:
         name: Source Engine - Linux 32-bit
-        path: build/*.zip
+        path: *.zip
 
   build-linux-amd64:
     runs-on: ubuntu-18.04
@@ -30,10 +31,11 @@ jobs:
     - name: Build linux-amd64
       run: |
         scripts/build-ubuntu-amd64.sh
+        zip -r build-linux-amd64.zip build
     - uses: actions/upload-artifact@v2
       with:
         name: Source Engine - Linux 64-bit
-        path: build/*.zip
+        path: *.zip
 
   build-android-armv7a:
     runs-on: ubuntu-18.04
@@ -43,10 +45,11 @@ jobs:
     - name: Build android-armv7a
       run: |
         scripts/build-android-armv7a.sh
+        zip -r build-android-armv7a.zip build
     - uses: actions/upload-artifact@v2
       with:
         name: Source Engine - Android armv7a
-        path: build/*.zip
+        path: *.zip
 
   build-windows-i386:
     runs-on: windows-2019
@@ -58,10 +61,12 @@ jobs:
         git submodule init && git submodule update
         ./waf.bat configure -T debug
         ./waf.bat build
+        choco install zip
+        zip -r build-windows-i386.zip build
     - uses: actions/upload-artifact@v2
       with:
         name: Source Engine - Windows 32-bit
-        path: build/*.zip
+        path: *.zip
 
   build-dedicated-windows-i386:
     runs-on: windows-2019

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: Source Engine - Linux 32-bit
-        path: *.zip
+        path: ./*.zip
 
   build-linux-amd64:
     runs-on: ubuntu-18.04
@@ -35,7 +35,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: Source Engine - Linux 64-bit
-        path: *.zip
+        path: ./*.zip
 
   build-android-armv7a:
     runs-on: ubuntu-18.04
@@ -49,7 +49,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: Source Engine - Android armv7a
-        path: *.zip
+        path: ./*.zip
 
   build-windows-i386:
     runs-on: windows-2019
@@ -66,7 +66,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: Source Engine - Windows 32-bit
-        path: *.zip
+        path: ./*.zip
 
   build-dedicated-windows-i386:
     runs-on: windows-2019


### PR DESCRIPTION
**What is?**

The artifacts are resources where the users can download in GitHub without doing a task in the repository like compiling and getting the compiled resources. Made to ease the development progress and give access to the testers.

Contains the compiled source files and can be debug opening Visual Studio to capture some exceptions or bugs. Also can copy and paste source files to test the engine in the game.

Every time gets commits, the workflow runs and upload artifacts to download.


- In the GitHub repository, go to: 

**Actions** >> 
![image](https://user-images.githubusercontent.com/49716252/186767505-8a00d848-c103-43da-a5b2-625cbccf3ed7.png)

<br/>

**Select workflow (select the build one, not the tests) or click View Workflow file from suspension points button** >> 

![image](https://user-images.githubusercontent.com/49716252/186768650-12d537e5-8db0-4346-a7c5-6ea627c63127.png)

<br/>

**Scroll down and you'll see the artifacts to download** >> **Download some artifact you want to test**

![image](https://user-images.githubusercontent.com/49716252/186768863-2bc25c16-9ad5-424b-95bb-b4629ae4b54f.png)

