### PR TITLE
Workaround macOS FL_Load_Glyph crash

### DIFF
--- a/vgui2/src/Scheme.cpp
+++ b/vgui2/src/Scheme.cpp
@@ -922,6 +922,12 @@ void CScheme::ReloadFontGlyphs()
 			{
 				int nRangeMin, nRangeMax;
 
+#ifdef OSX
+				if (tall == 11) { // workaround FL_Load_Glyph error
+					tall = 12;
+				}
+#endif
+
 				if ( GetFontRange( fontdata->GetString( "name" ), nRangeMin, nRangeMax ) )
 				{
 					// add the new set


### PR DESCRIPTION
Occurs when non ASCII character printed on console