### PR TITLE
Add forgotten VTF 7.5 support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This project is using waf buildsystem. If you have waf-related questions look ht
 - Modern toolchains support
 - Fixed many undefined behaviours
 - Touch support( even on windows/linux/osx )
+- VTF 7.5 support
 - PBR support
 - bsp v19-v21 support( bsp v21 support is partial, portal 2 and csgo maps works fine )
 - mdl v46-49 support


### PR DESCRIPTION
VTF 7.5 support was added some time ago, the issue #83 was solved.  
This is important for making artists, mappers and modelers know.


@nillerusr I think you forgot to add that in the README.