### PR TITLE
[Windows] Fix dedicated server build

### DIFF
--- a/dedicated/wscript
+++ b/dedicated/wscript
@@ -39,6 +39,10 @@ def build(bld):
 	if bld.env.DEST_OS == 'win32':
 		source += [
 			'sys_windows.cpp',
+			'vgui/CreateMultiplayerGameServerPage.cpp',
+			'vgui/MainPanel.cpp',
+			'../public/vgui_controls/vgui_controls.cpp',
+			'vgui/vguihelpers.cpp',
 			'console/TextConsoleWin32.cpp'
 		]
 	else:

--- a/dedicated/wscript
+++ b/dedicated/wscript
@@ -60,8 +60,8 @@ def build(bld):
 
 	libs = ['tier0','vpklib','tier1','tier2','tier3','vstdlib','steam_api','appframework','mathlib', 'EDIT']
 
-        if bld.env.DEST_OS == 'win32':
-		 libs += ['vgui_controls', 'USER32', 'SHELL32']
+	if bld.env.DEST_OS == 'win32':
+		libs += ['vgui_controls', 'USER32', 'SHELL32']
 
 	install_path = bld.env.LIBDIR
 

--- a/dedicated/wscript
+++ b/dedicated/wscript
@@ -38,7 +38,8 @@ def build(bld):
 
 	if bld.env.DEST_OS == 'win32':
 		source += [
-			'sys_windows.cpp'
+			'sys_windows.cpp',
+			'console/TextConsoleWin32.cpp'
 		]
 	else:
 		source += [
@@ -58,6 +59,9 @@ def build(bld):
 	defines = []
 
 	libs = ['tier0','vpklib','tier1','tier2','tier3','vstdlib','steam_api','appframework','mathlib', 'EDIT']
+
+        if bld.env.DEST_OS == 'win32':
+		 libs += ['vgui_controls', 'USER32', 'SHELL32']
 
 	install_path = bld.env.LIBDIR
 


### PR DESCRIPTION
Dedicated server is not build on Windows, see CI log:

https://github.com/nillerusr/source-engine/actions/runs/7013944669/job/19080884554

```
sys_ded.cpp.5.o : error LNK2001: unresolved external symbol "public: virtual int __cdecl CTextConsoleWin32::GetWidth(void)" (?GetWidth@CTextConsoleWin32@@UEAAHXZ)

sys_ded.cpp.5.o : error LNK2001: unresolved external symbol "public: virtual void __cdecl CTextConsoleWin32::SetVisible(bool)" (?SetVisible@CTextConsoleWin32@@UEAAX_N@Z)

sys_ded.cpp.5.o : error LNK2001: unresolved external symbol "char * gpszCvars" (?gpszCvars@@3PEADEA)

basefilesystem.cpp.5.o : error LNK2019: unresolved external symbol __imp_SHGetFileInfoW referenced in function "public: virtual bool __cdecl CBaseFileSystem::GetFileTypeForFullPath(char const *,wchar_t *,unsigned __int64)" (?GetFileTypeForFullPath@CBaseFileSystem@@UEAA_NPEBDPEA_W_K@Z)

sys_windows.cpp.5.o : error LNK2019: unresolved external symbol __imp_PostQuitMessage referenced in function "public: virtual void __cdecl CSys::ErrorMessage(int,char const *)" (?ErrorMessage@CSys@@UEAAXHPEBD@Z)

sys_windows.cpp.5.o : error LNK2019: unresolved external symbol __imp_CommandLineToArgvW referenced in function DedicatedMain

sys_windows.cpp.5.o : error LNK2019: unresolved external symbol "void __cdecl VGUIPrintf(char const *)" (?VGUIPrintf@@YAXPEBD@Z) referenced in function "public: virtual void __cdecl CSys::ConsoleOutput(char *)" (?ConsoleOutput@CSys@@UEAAXPEAD@Z)

D:\a\source-engine\source-engine\build\dedicated\dedicated.dll : warning LNK4088: image being generated due to /FORCE option; image may not run
```

`/FORCE` option hides linker errors and result image is not runnable.

Now it should be fixed.

Closes https://github.com/nillerusr/source-engine/issues/310