### PR TITLE
[FIX] Lowered weapon shooting fix for HL2.

### DIFF
--- a/game/server/hl2/weapon_shotgun.cpp
+++ b/game/server/hl2/weapon_shotgun.cpp
@@ -552,9 +552,9 @@ void CWeaponShotgun::SecondaryAttack( void )
 //-----------------------------------------------------------------------------
 // Purpose: Override so shotgun can do mulitple reloads in a row
 //-----------------------------------------------------------------------------
-void CWeaponShotgun::ItemPostFrame( void )
+void CWeaponShotgun::ItemPostFrame(void)
 {
-	CBasePlayer *pOwner = ToBasePlayer( GetOwner() );
+	CBasePlayer* pOwner = ToBasePlayer(GetOwner());
 	if (!pOwner)
 	{
 		return;
@@ -563,23 +563,23 @@ void CWeaponShotgun::ItemPostFrame( void )
 	if (m_bInReload)
 	{
 		// If I'm primary firing and have one round stop reloading and fire
-		if ((pOwner->m_nButtons & IN_ATTACK ) && (m_iClip1 >=1))
+		if ((pOwner->m_nButtons & IN_ATTACK) && (m_iClip1 >= 1))
 		{
-			m_bInReload		= false;
-			m_bNeedPump		= false;
+			m_bInReload = false;
+			m_bNeedPump = false;
 			m_bDelayedFire1 = true;
 		}
 		// If I'm secondary firing and have one round stop reloading and fire
-		else if ((pOwner->m_nButtons & IN_ATTACK2 ) && (m_iClip1 >=2))
+		else if ((pOwner->m_nButtons & IN_ATTACK2) && (m_iClip1 >= 2))
 		{
-			m_bInReload		= false;
-			m_bNeedPump		= false;
+			m_bInReload = false;
+			m_bNeedPump = false;
 			m_bDelayedFire2 = true;
 		}
 		else if (m_flNextPrimaryAttack <= gpGlobals->curtime)
 		{
 			// If out of ammo end reload
-			if (pOwner->GetAmmoCount(m_iPrimaryAmmoType) <=0)
+			if (pOwner->GetAmmoCount(m_iPrimaryAmmoType) <= 0)
 			{
 				FinishReload();
 				return;
@@ -599,9 +599,9 @@ void CWeaponShotgun::ItemPostFrame( void )
 		}
 	}
 	else
-	{			
+	{
 		// Make shotgun shell invisible
-		SetBodygroup(1,1);
+		SetBodygroup(1, 1);
 	}
 
 	if ((m_bNeedPump) && (m_flNextPrimaryAttack <= gpGlobals->curtime))
@@ -609,78 +609,87 @@ void CWeaponShotgun::ItemPostFrame( void )
 		Pump();
 		return;
 	}
-	
-	// Shotgun uses same timing and ammo for secondary attack
-	if ((m_bDelayedFire2 || pOwner->m_nButtons & IN_ATTACK2)&&(m_flNextPrimaryAttack <= gpGlobals->curtime))
+
+#ifdef GAME_DLL
+	if (!m_bLowered)
 	{
-		m_bDelayedFire2 = false;
-		
-		if ( (m_iClip1 <= 1 && UsesClipsForAmmo1()))
+#endif // GAME_DLL
+
+
+		// Shotgun uses same timing and ammo for secondary attack
+		if ((m_bDelayedFire2 || pOwner->m_nButtons & IN_ATTACK2) && (m_flNextPrimaryAttack <= gpGlobals->curtime))
 		{
-			// If only one shell is left, do a single shot instead	
-			if ( m_iClip1 == 1 )
+			m_bDelayedFire2 = false;
+
+			if ((m_iClip1 <= 1 && UsesClipsForAmmo1()))
 			{
+				// If only one shell is left, do a single shot instead	
+				if (m_iClip1 == 1)
+				{
+					PrimaryAttack();
+				}
+				else if (!pOwner->GetAmmoCount(m_iPrimaryAmmoType))
+				{
+					DryFire();
+				}
+				else
+				{
+					StartReload();
+				}
+			}
+
+			// Fire underwater?
+			else if (GetOwner()->GetWaterLevel() == 3 && m_bFiresUnderwater == false)
+			{
+				WeaponSound(EMPTY);
+				m_flNextPrimaryAttack = gpGlobals->curtime + 0.2;
+				return;
+			}
+			else
+			{
+				// If the firing button was just pressed, reset the firing time
+				if (pOwner->m_afButtonPressed & IN_ATTACK)
+				{
+					m_flNextPrimaryAttack = gpGlobals->curtime;
+				}
+				SecondaryAttack();
+			}
+		}
+		else if ((m_bDelayedFire1 || pOwner->m_nButtons & IN_ATTACK) && m_flNextPrimaryAttack <= gpGlobals->curtime)
+		{
+			m_bDelayedFire1 = false;
+			if ((m_iClip1 <= 0 && UsesClipsForAmmo1()) || (!UsesClipsForAmmo1() && !pOwner->GetAmmoCount(m_iPrimaryAmmoType)))
+			{
+				if (!pOwner->GetAmmoCount(m_iPrimaryAmmoType))
+				{
+					DryFire();
+				}
+				else
+				{
+					StartReload();
+				}
+			}
+			// Fire underwater?
+			else if (pOwner->GetWaterLevel() == 3 && m_bFiresUnderwater == false)
+			{
+				WeaponSound(EMPTY);
+				m_flNextPrimaryAttack = gpGlobals->curtime + 0.2;
+				return;
+			}
+			else
+			{
+				// If the firing button was just pressed, reset the firing time
+				CBasePlayer* pPlayer = ToBasePlayer(GetOwner());
+				if (pPlayer && pPlayer->m_afButtonPressed & IN_ATTACK)
+				{
+					m_flNextPrimaryAttack = gpGlobals->curtime;
+				}
 				PrimaryAttack();
 			}
-			else if (!pOwner->GetAmmoCount(m_iPrimaryAmmoType))
-			{
-				DryFire();
-			}
-			else
-			{
-				StartReload();
-			}
 		}
-
-		// Fire underwater?
-		else if (GetOwner()->GetWaterLevel() == 3 && m_bFiresUnderwater == false)
-		{
-			WeaponSound(EMPTY);
-			m_flNextPrimaryAttack = gpGlobals->curtime + 0.2;
-			return;
-		}
-		else
-		{
-			// If the firing button was just pressed, reset the firing time
-			if ( pOwner->m_afButtonPressed & IN_ATTACK )
-			{
-				 m_flNextPrimaryAttack = gpGlobals->curtime;
-			}
-			SecondaryAttack();
-		}
+#ifdef GAME_DLL
 	}
-	else if ( (m_bDelayedFire1 || pOwner->m_nButtons & IN_ATTACK) && m_flNextPrimaryAttack <= gpGlobals->curtime)
-	{
-		m_bDelayedFire1 = false;
-		if ( (m_iClip1 <= 0 && UsesClipsForAmmo1()) || ( !UsesClipsForAmmo1() && !pOwner->GetAmmoCount(m_iPrimaryAmmoType) ) )
-		{
-			if (!pOwner->GetAmmoCount(m_iPrimaryAmmoType))
-			{
-				DryFire();
-			}
-			else
-			{
-				StartReload();
-			}
-		}
-		// Fire underwater?
-		else if (pOwner->GetWaterLevel() == 3 && m_bFiresUnderwater == false)
-		{
-			WeaponSound(EMPTY);
-			m_flNextPrimaryAttack = gpGlobals->curtime + 0.2;
-			return;
-		}
-		else
-		{
-			// If the firing button was just pressed, reset the firing time
-			CBasePlayer *pPlayer = ToBasePlayer( GetOwner() );
-			if ( pPlayer && pPlayer->m_afButtonPressed & IN_ATTACK )
-			{
-				 m_flNextPrimaryAttack = gpGlobals->curtime;
-			}
-			PrimaryAttack();
-		}
-	}
+#endif // GAME_DLL
 
 	if ( pOwner->m_nButtons & IN_RELOAD && UsesClipsForAmmo1() && !m_bInReload ) 
 	{

--- a/game/shared/basecombatweapon_shared.cpp
+++ b/game/shared/basecombatweapon_shared.cpp
@@ -1647,118 +1647,127 @@ void CBaseCombatWeapon::ItemPreFrame( void )
 //====================================================================================
 // WEAPON BEHAVIOUR
 //====================================================================================
-void CBaseCombatWeapon::ItemPostFrame( void )
+void CBaseCombatWeapon::ItemPostFrame(void)
 {
-	CBasePlayer *pOwner = ToBasePlayer( GetOwner() );
+	CBasePlayer* pOwner = ToBasePlayer(GetOwner());
 	if (!pOwner)
 		return;
+
 
 	UpdateAutoFire();
 
 	//Track the duration of the fire
 	//FIXME: Check for IN_ATTACK2 as well?
 	//FIXME: What if we're calling ItemBusyFrame?
-	m_fFireDuration = ( pOwner->m_nButtons & IN_ATTACK ) ? ( m_fFireDuration + gpGlobals->frametime ) : 0.0f;
+	m_fFireDuration = (pOwner->m_nButtons & IN_ATTACK) ? (m_fFireDuration + gpGlobals->frametime) : 0.0f;
 
-	if ( UsesClipsForAmmo1() )
+	if (UsesClipsForAmmo1())
 	{
 		CheckReload();
 	}
 
 	bool bFired = false;
-
-	// Secondary attack has priority
-	if ((pOwner->m_nButtons & IN_ATTACK2) && (m_flNextSecondaryAttack <= gpGlobals->curtime))
+#ifdef GAME_DLL
+	if (!m_bLowered)
 	{
-		if (UsesSecondaryAmmo() && pOwner->GetAmmoCount(m_iSecondaryAmmoType)<=0 )
-		{
-			if (m_flNextEmptySoundTime < gpGlobals->curtime)
-			{
-				WeaponSound(EMPTY);
-				m_flNextSecondaryAttack = m_flNextEmptySoundTime = gpGlobals->curtime + 0.5;
-			}
-		}
-		else if (pOwner->GetWaterLevel() == 3 && m_bAltFiresUnderwater == false)
-		{
-			// This weapon doesn't fire underwater
-			WeaponSound(EMPTY);
-			m_flNextPrimaryAttack = gpGlobals->curtime + 0.2;
-			return;
-		}
-		else
-		{
-			// FIXME: This isn't necessarily true if the weapon doesn't have a secondary fire!
-			// For instance, the crossbow doesn't have a 'real' secondary fire, but it still 
-			// stops the crossbow from firing on the 360 if the player chooses to hold down their
-			// zoom button. (sjb) Orange Box 7/25/2007
-#if !defined(CLIENT_DLL)
-			if( !IsX360() || !ClassMatches("weapon_crossbow") )
 #endif
+		// Secondary attack has priority
+		if ((pOwner->m_nButtons & IN_ATTACK2) && (m_flNextSecondaryAttack <= gpGlobals->curtime))
+		{
+			if (UsesSecondaryAmmo() && pOwner->GetAmmoCount(m_iSecondaryAmmoType) <= 0)
 			{
-				bFired = ShouldBlockPrimaryFire();
-			}
-
-			SecondaryAttack();
-
-			// Secondary ammo doesn't have a reload animation
-			if ( UsesClipsForAmmo2() )
-			{
-				// reload clip2 if empty
-				if (m_iClip2 < 1)
+				if (m_flNextEmptySoundTime < gpGlobals->curtime)
 				{
-					pOwner->RemoveAmmo( 1, m_iSecondaryAmmoType );
-					m_iClip2 = m_iClip2 + 1;
+					WeaponSound(EMPTY);
+					m_flNextSecondaryAttack = m_flNextEmptySoundTime = gpGlobals->curtime + 0.5;
+				}
+			}
+			else if (pOwner->GetWaterLevel() == 3 && m_bAltFiresUnderwater == false)
+			{
+				// This weapon doesn't fire underwater
+				WeaponSound(EMPTY);
+				m_flNextPrimaryAttack = gpGlobals->curtime + 0.2;
+				return;
+			}
+			else
+			{
+				// FIXME: This isn't necessarily true if the weapon doesn't have a secondary fire!
+				// For instance, the crossbow doesn't have a 'real' secondary fire, but it still 
+				// stops the crossbow from firing on the 360 if the player chooses to hold down their
+				// zoom button. (sjb) Orange Box 7/25/2007
+#if !defined(CLIENT_DLL)
+				if (!IsX360() || !ClassMatches("weapon_crossbow"))
+#endif
+				{
+					bFired = ShouldBlockPrimaryFire();
+				}
+
+				SecondaryAttack();
+
+				// Secondary ammo doesn't have a reload animation
+				if (UsesClipsForAmmo2())
+				{
+					// reload clip2 if empty
+					if (m_iClip2 < 1)
+					{
+						pOwner->RemoveAmmo(1, m_iSecondaryAmmoType);
+						m_iClip2 = m_iClip2 + 1;
+					}
 				}
 			}
 		}
-	}
-	
-	if ( !bFired && (pOwner->m_nButtons & IN_ATTACK) && (m_flNextPrimaryAttack <= gpGlobals->curtime))
-	{
-		// Clip empty? Or out of ammo on a no-clip weapon?
-		if ( !IsMeleeWeapon() &&  
-			(( UsesClipsForAmmo1() && m_iClip1 <= 0) || ( !UsesClipsForAmmo1() && pOwner->GetAmmoCount(m_iPrimaryAmmoType)<=0 )) )
-		{
-			HandleFireOnEmpty();
-		}
-		else if (pOwner->GetWaterLevel() == 3 && m_bFiresUnderwater == false)
-		{
-			// This weapon doesn't fire underwater
-			WeaponSound(EMPTY);
-			m_flNextPrimaryAttack = gpGlobals->curtime + 0.2;
-			return;
-		}
-		else
-		{
-			//NOTENOTE: There is a bug with this code with regards to the way machine guns catch the leading edge trigger
-			//			on the player hitting the attack key.  It relies on the gun catching that case in the same frame.
-			//			However, because the player can also be doing a secondary attack, the edge trigger may be missed.
-			//			We really need to hold onto the edge trigger and only clear the condition when the gun has fired its
-			//			first shot.  Right now that's too much of an architecture change -- jdw
-			
-			// If the firing button was just pressed, or the alt-fire just released, reset the firing time
-			if ( ( pOwner->m_afButtonPressed & IN_ATTACK ) || ( pOwner->m_afButtonReleased & IN_ATTACK2 ) )
-			{
-				 m_flNextPrimaryAttack = gpGlobals->curtime;
-			}
 
-			PrimaryAttack();
-
-			if ( AutoFiresFullClip() )
+		if (!bFired && (pOwner->m_nButtons & IN_ATTACK) && (m_flNextPrimaryAttack <= gpGlobals->curtime))
+		{
+			// Clip empty? Or out of ammo on a no-clip weapon?
+			if (!IsMeleeWeapon() &&
+				((UsesClipsForAmmo1() && m_iClip1 <= 0) || (!UsesClipsForAmmo1() && pOwner->GetAmmoCount(m_iPrimaryAmmoType) <= 0)))
 			{
-				m_bFiringWholeClip = true;
+				HandleFireOnEmpty();
 			}
+			else if (pOwner->GetWaterLevel() == 3 && m_bFiresUnderwater == false)
+			{
+				// This weapon doesn't fire underwater
+				WeaponSound(EMPTY);
+				m_flNextPrimaryAttack = gpGlobals->curtime + 0.2;
+				return;
+			}
+			else
+			{
+
+				//NOTENOTE: There is a bug with this code with regards to the way machine guns catch the leading edge trigger
+				//			on the player hitting the attack key.  It relies on the gun catching that case in the same frame.
+				//			However, because the player can also be doing a secondary attack, the edge trigger may be missed.
+				//			We really need to hold onto the edge trigger and only clear the condition when the gun has fired its
+				//			first shot.  Right now that's too much of an architecture change -- jdw
+
+				// If the firing button was just pressed, or the alt-fire just released, reset the firing time
+				if ((pOwner->m_afButtonPressed & IN_ATTACK) || (pOwner->m_afButtonReleased & IN_ATTACK2))
+				{
+					m_flNextPrimaryAttack = gpGlobals->curtime;
+				}
+
+				PrimaryAttack();
+
+				if (AutoFiresFullClip())
+				{
+					m_bFiringWholeClip = true;
+				}
 
 #ifdef CLIENT_DLL
-			pOwner->SetFiredWeapon( true );
+				pOwner->SetFiredWeapon(true);
 #endif
+			}
 		}
+#ifdef GAME_DLL
 	}
+#endif
+
 
 	// -----------------------
 	//  Reload pressed / Clip Empty
 	// -----------------------
-	if ( ( pOwner->m_nButtons & IN_RELOAD ) && UsesClipsForAmmo1() && !m_bInReload ) 
+	if ((pOwner->m_nButtons & IN_RELOAD) && UsesClipsForAmmo1() && !m_bInReload)
 	{
 		// reload when reload is pressed, or if no buttons are down and weapon is empty.
 		Reload();
@@ -1771,7 +1780,7 @@ void CBaseCombatWeapon::ItemPostFrame( void )
 	if (!((pOwner->m_nButtons & IN_ATTACK) || (pOwner->m_nButtons & IN_ATTACK2) || (CanReload() && pOwner->m_nButtons & IN_RELOAD)))
 	{
 		// no fire buttons down or reloading
-		if ( !ReloadOrSwitchWeapons() && ( m_bInReload == false ) )
+		if (!ReloadOrSwitchWeapons() && (m_bInReload == false))
 		{
 			WeaponIdle();
 		}

--- a/game/shared/basecombatweapon_shared.cpp
+++ b/game/shared/basecombatweapon_shared.cpp
@@ -2588,6 +2588,9 @@ IMPLEMENT_NETWORKCLASS_ALIASED( BaseCombatWeapon, DT_BaseCombatWeapon )
 //-----------------------------------------------------------------------------// 
 BEGIN_DATADESC( CBaseCombatWeapon )
 
+	DEFINE_FIELD(m_bLowered, FIELD_BOOLEAN),
+	DEFINE_FIELD(m_flRaiseTime, FIELD_TIME),
+
 	DEFINE_FIELD( m_flNextPrimaryAttack, FIELD_TIME ),
 	DEFINE_FIELD( m_flNextSecondaryAttack, FIELD_TIME ),
 	DEFINE_FIELD( m_flTimeWeaponIdle, FIELD_TIME ),

--- a/game/shared/basecombatweapon_shared.cpp
+++ b/game/shared/basecombatweapon_shared.cpp
@@ -94,6 +94,11 @@ CBaseCombatWeapon::CBaseCombatWeapon() : BASECOMBATWEAPON_DERIVED_FROM()
 
 	m_hWeaponFileInfo = GetInvalidWeaponInfoHandle();
 
+#ifdef GAME_DLL
+	m_bLowered = false;
+	m_flRaiseTime = gpGlobals->curtime;
+#endif
+
 #if defined( TF_DLL )
 	UseClientSideAnimation();
 #endif

--- a/game/shared/basecombatweapon_shared.h
+++ b/game/shared/basecombatweapon_shared.h
@@ -526,7 +526,6 @@ private:
 	CNetworkVar( CBaseCombatCharacterHandle, m_hOwner );				// Player carrying this weapon
 
 protected:
-
 #ifdef GAME_DLL
 	bool			m_bLowered;			// Whether the viewmodel is raised or lowered
 	float			m_flRaiseTime;		// If lowered, the time we should raise the viewmodel

--- a/game/shared/basecombatweapon_shared.h
+++ b/game/shared/basecombatweapon_shared.h
@@ -526,6 +526,12 @@ private:
 	CNetworkVar( CBaseCombatCharacterHandle, m_hOwner );				// Player carrying this weapon
 
 protected:
+
+#ifdef GAME_DLL
+	bool			m_bLowered;			// Whether the viewmodel is raised or lowered
+	float			m_flRaiseTime;		// If lowered, the time we should raise the viewmodel
+#endif
+
 #if defined ( TF_CLIENT_DLL ) || defined ( TF_DLL )
 	// Regulate crit frequency to reduce client-side seed hacking
 	void					AddToCritBucket( float flAmount );

--- a/game/shared/hl2/basehlcombatweapon_shared.cpp
+++ b/game/shared/hl2/basehlcombatweapon_shared.cpp
@@ -34,8 +34,6 @@ END_NETWORK_TABLE()
 //---------------------------------------------------------
 BEGIN_DATADESC( CBaseHLCombatWeapon )
 
-	DEFINE_FIELD( m_bLowered,			FIELD_BOOLEAN ),
-	DEFINE_FIELD( m_flRaiseTime,		FIELD_TIME ),
 	DEFINE_FIELD( m_flHolsterTime,		FIELD_TIME ),
 	DEFINE_FIELD( m_iPrimaryAttacks,	FIELD_INTEGER ),
 	DEFINE_FIELD( m_iSecondaryAttacks,	FIELD_INTEGER ),

--- a/game/shared/hl2/basehlcombatweapon_shared.h
+++ b/game/shared/hl2/basehlcombatweapon_shared.h
@@ -58,6 +58,10 @@ public:
 
 protected:
 
+#ifndef GAME_DLL
+	bool			m_bLowered;			// Whether the viewmodel is raised or lowered
+	float			m_flRaiseTime;		// If lowered, the time we should raise the viewmodel
+#endif
 	float			m_flHolsterTime;	// When the weapon was holstered
 };
 

--- a/game/shared/hl2/basehlcombatweapon_shared.h
+++ b/game/shared/hl2/basehlcombatweapon_shared.h
@@ -58,8 +58,6 @@ public:
 
 protected:
 
-	bool			m_bLowered;			// Whether the viewmodel is raised or lowered
-	float			m_flRaiseTime;		// If lowered, the time we should raise the viewmodel
 	float			m_flHolsterTime;	// When the weapon was holstered
 };
 


### PR DESCRIPTION
Almost all shooting weapons uses `CBaseHLCombatWeapon` as a base. Lowering system coded in there. But the Attach code coded in `CBaseCombatWeapon` instead. And lowered weapon, that should not fire, still fires, because `CBaseCombatWeapon` class dont know is weapon lowered or not.

I fixed it by moving SERVERSIDE m_bLowered and m_flRaiseTime from `CBaseHLCombatWeapon` to `CBaseCombatWeapon`. I think this way of fixing this bug is ok, because even tho `CBaseCombatWeapon` doesnt to do any calculations and checks for lowering weapon, it still have Lower() and CanLower() functions. They just always return false. To prevent anything bad happening for weapons that doesn't use lowering system, i didn't change this functions.

Also i manually fixed it in shotgun. There is their own Attack code.