### PR TITLE
Fix wrong collision box scaling of physics props

### DIFF
--- a/game/client/c_baseanimating.cpp
+++ b/game/client/c_baseanimating.cpp
@@ -4981,9 +4981,10 @@ bool C_BaseAnimating::TestHitboxes( const Ray_t &ray, unsigned int fContentsMask
 				VPhysicsSetObject( pReplace );
 			}
 		}
+		return true;
 	}
 
-	return true;
+	return false;
 }
 
 

--- a/game/server/baseanimating.cpp
+++ b/game/server/baseanimating.cpp
@@ -2693,8 +2693,9 @@ bool CBaseAnimating::TestHitboxes( const Ray_t &ray, unsigned int fContentsMask,
 		tr.surface.name = "**studio**";
 		tr.surface.flags = SURF_HITBOX;
 		tr.surface.surfaceProps = physprops->GetSurfaceIndex( pBone->pszSurfaceProp() );
+		return true;
 	}
-	return true;
+	return false;
 }
 
 void CBaseAnimating::InitBoneControllers ( void ) // FIXME: rename

--- a/game/server/props.cpp
+++ b/game/server/props.cpp
@@ -6071,17 +6071,17 @@ bool UTIL_CreateScaledPhysObject( CBaseAnimating *pInstance, float flScale )
 	pInstance->VPhysicsDestroyObject();
 	pInstance->VPhysicsSetObject( pNewObject );
 
+	// Scale the base model as well
+	pInstance->SetModelScale( flScale );
+
 	// Increase our model bounds
 	const model_t *pModel = modelinfo->GetModel( pInstance->GetModelIndex() );
 	if ( pModel )
 	{
 		Vector mins, maxs;
 		modelinfo->GetModelBounds( pModel, mins, maxs );
-		pInstance->SetCollisionBounds( mins*flScale, maxs*flScale );
+		pInstance->SetCollisionBounds( mins, maxs );
 	}
-
-	// Scale the base model as well
-	pInstance->SetModelScale( flScale );
 
 	if ( pInstance->GetParent() )
 	{


### PR DESCRIPTION
For example:
![SetModelScale](https://github.com/user-attachments/assets/6a73105a-ecd9-45d6-a0a3-0c1396d01c20)
Create a prop_physics entity with SetModelScale(2) then Activate()

Before the fix:
![before](https://github.com/user-attachments/assets/c7fda4a1-dd22-4698-8904-913e99d9e45a)

After the fix:
![after](https://github.com/user-attachments/assets/95604f05-d0f4-4f08-b13e-dc09e79afc0f)

What is wrong:
SetCollisionBounds doesn't require scale information
It reads the scaling information directly from GetModelScale
Which is SetModelScale will do