### PR TITLE
Fix: Port to macOS 15.5 (Sequoia) – clang++ compatibility, std::swap,…

### DIFF
--- a/public/datamodel/dmattributevar.h
+++ b/public/datamodel/dmattributevar.h
@@ -105,6 +105,9 @@ public:
 	// NULL check
 	bool operator!() const;
 
+	// Returns the underlying DmElementHandle_t data
+	const DmElementHandle_t& Data() const;
+
 	// Assignment.. wish I knew how to un-inline these methods
 	template <class S> CDmaElement<T> &operator=( S* pElement )
 	{
@@ -1134,6 +1137,12 @@ inline void CDmaElement<T>::InitAndCreate( CDmElement *pOwner, const char *pAttr
 
 	// this has to happen AFTER set so the set happens before FATTRIB_READONLY
 	m_pAttribute->AddFlag( flags | FATTRIB_MUSTCOPY );
+}
+
+template <class T>
+inline const DmElementHandle_t& CDmaElement<T>::Data() const 
+{
+    return Value();
 }
 
 template <class T>

--- a/public/tier1/utlblockmemory.h
+++ b/public/tier1/utlblockmemory.h
@@ -137,10 +137,10 @@ CUtlBlockMemory<T,I>::~CUtlBlockMemory()
 template< class T, class I >
 void CUtlBlockMemory<T,I>::Swap( CUtlBlockMemory< T, I > &mem )
 {
-	this->swap( m_pMemory, mem.m_pMemory );
-	this->swap( m_nBlocks, mem.m_nBlocks );
-	this->swap( m_nIndexMask, mem.m_nIndexMask );
-	this->swap( m_nIndexShift, mem.m_nIndexShift );
+	std::swap( m_pMemory, mem.m_pMemory );
+	std::swap( m_nBlocks, mem.m_nBlocks );
+	std::swap( m_nIndexMask, mem.m_nIndexMask );
+	std::swap( m_nIndexShift, mem.m_nIndexShift );
 }
 
 


### PR DESCRIPTION
Sequoia port for MacOs15.5

1. Added Methods
   File: dmattributevar.h
   - Added method: 
     ```cpp
     template <class T>
     inline const DmElementHandle_t& CDmaElement<T>::Data() const {
         return Value();
     }
     ```
   - Purpose: fix compatibility error caused by missing `Data()` method; correctly uses `Value()` as return type.

2. Replacement of std::swap
   File: ./public/tier1/utlblockmemory.h
   - Replaced instance of `this->swap(` with `std::swap(` without changing arguments or logic.

