### PR TITLE
Fix console and chat text selection.

### DIFF
--- a/vgui2/vgui_controls/RichText.cpp
+++ b/vgui2/vgui_controls/RichText.cpp
@@ -862,6 +862,12 @@ void RichText::Paint()
 		if ( m_LineBreaks.IsValidIndex( lineBreakIndexIndex ) && m_LineBreaks[lineBreakIndexIndex] < iLim )
 			iLim = m_LineBreaks[lineBreakIndexIndex];
 
+		// Stop when entering or exiting the selected range
+		if ( i < selection0 && iLim >= selection0 )
+			iLim = selection0;
+		if ( i >= selection0 && i < selection1 && iLim >= selection1 )
+			iLim = selection1;
+
 		// Handle non-drawing characters specially
 		for ( int iT = i; iT < iLim; iT++ )
 		{


### PR DESCRIPTION
Somewhere around 2013, many Source engine games got the same bug: the text selection in the console was drawn incorrectly. Instead of the selection being drawn only on the directly selected text, it was drawn on the entire line.

This commit corrects this situation.

Before:
<img width="544" height="212" alt="image" src="https://github.com/user-attachments/assets/3e70c797-b12f-44c5-be78-aaadce8753a7" />

After:
<img width="589" height="282" alt="image" src="https://github.com/user-attachments/assets/0cbc3b5f-91c2-45a5-afbe-f4d4ce9b568d" />

This change was tested in HL2, CSS, HL2MP and DOD. CLang and GCC. MSVC needs test. 
